### PR TITLE
adds explaination for metadata usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ pip install lookatme.contrib.image_ueberzug
 Use images! For now, only local images are supported. Remote image support
 will be added later.
 
+Enable this plugin by adding it to the metadata in the head of the markdown file.
+
+```txt
+---
+title: <title>
+author: <author>
+extensions:
+  - image_ueberzug
+---
+```
+
 Use the text of the image to indicate the height (number of rows) that the
 image should use when rendered. The example below will render
 `path/to/image.png` with a height of `7` rows:


### PR DESCRIPTION
Adds missing part in documentation that it must be added to the metadata. Otherwise it might be confusing when is shows only links.