### PR TITLE
Update to support lookatme 3.0

### DIFF
--- a/lookatme/contrib/image_ueberzug.py
+++ b/lookatme/contrib/image_ueberzug.py
@@ -26,8 +26,7 @@ def root_urwid_widget(to_wrap):
     CANVAS = ueberzug.Canvas().__enter__()
     return uw_uz.Container(CANVAS, urwid.Pile([to_wrap]), visibility=ueberzug.Visibility.VISIBLE)
 
-
-def image(link_uri, title, text):
+def make_urwid_image(link_uri: str, height: str):
     base_dir = lookatme.config.SLIDE_SOURCE_DIR
     full_path = os.path.join(base_dir, link_uri)
 
@@ -39,13 +38,24 @@ def image(link_uri, title, text):
         scaler=ueberzug.ScalerOption.FIT_CONTAIN.value,
     )
     try:
-        height = int(text)
+        height = int(height)
     except:
         height = 30
     blank_box = urwid.BoxAdapter(urwid.SolidFill(" "), height=height)
-    img = uw_uz.Image(placement, blank_box)
-    return [img]
+    return uw_uz.Image(placement, blank_box)
 
+def image(link_uri, title, text):
+    """This method is called by lookatme 2.0"""
+    image = make_urwid_image(link_uri, content)
+    return [image]
+
+def render_image(token, ctx):
+    """This method is called by lookatme 3.0"""
+    attrs = dict(token["attrs"])
+    content = token["content"]
+    link_uri = attrs.get("src", "")
+    image = make_urwid_image(link_uri, content)
+    ctx.widget_add(image)
 
 def shutdown():
     if CANVAS is None:


### PR DESCRIPTION
Basic changes to support the new API of lookatme 3 while maintaining support for 2.0.
`ueberzug` lives on: https://github.com/ueber-devel/ueberzug